### PR TITLE
Issue #1 - targetCompatability was specified without sourceCompatability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ repositories {
 
 mainClassName = 'com.krohinc.dns.DnsMadeEasyManualUpdater'
 targetCompatibility = 1.5
+sourceCompatibility = 1.5
 version = '1.1.0'
 
 jar {


### PR DESCRIPTION
Under JDK 1.7 if you specify targetCompatability you need to specify a sourceCompability because sourceCompability defaults to 1.7.

The build was failing with this after migrating to JDK 1.7:

>    target release 1.5 conflicts with default source release 1.7
